### PR TITLE
Fix issue with BOOST libraries not installed in standard location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ endif(OPENMP_FOUND)
 
 # Search for boost and nlopt
 find_package(Boost 1.47 COMPONENTS random REQUIRED)
+include_directories(${Boost_INCLUDE_DIRS})
 find_package(NLopt REQUIRED)
 include_directories(${NLOPT_INCLUDE_DIRS})
 


### PR DESCRIPTION
If BOOST libraries are not in the standard directories then need
to explicitly include_directories in CMakeLists.txt file