### PR TITLE
Refactor: make get_children_id_score a method of node

### DIFF
--- a/src/Inference.h
+++ b/src/Inference.h
@@ -226,7 +226,7 @@ void Inference::compute_t_table(const vector<vector<double>> &D, const vector<in
     {
 
         this->t.compute_tree(D[i], r);
-        std::map<int, double> scores_vec = this->t.get_children_id_score(this->t.root);
+        std::map<int, double> scores_vec = this->t.root->get_children_id_score();
 
         this->t_scores.push_back(scores_vec);
 
@@ -385,7 +385,7 @@ Tree * Inference::comparison(int m, double gamma, unsigned move_id, const vector
             {
                 // find the node that is deleted
                 // use the get_id_score function since it returns a map having node id as a key
-                map<int,double> t_prime_scores = t_prime.get_children_id_score(t_prime.root);
+                map<int,double> t_prime_scores = t_prime.root->get_children_id_score();
                 Node* deleted = nullptr;
                 for (auto const &t_node : t.root->get_descendents(false)) // root won't be contained!
                     if (!t_prime_scores.count(t_node->id))
@@ -418,7 +418,7 @@ Tree * Inference::comparison(int m, double gamma, unsigned move_id, const vector
             else // insert
             {
                 // find the node that is inserted in t_prime
-                map<int,double> t_scores = t.get_children_id_score(t.root);
+                map<int,double> t_scores = t.root->get_children_id_score();
 
                 Node* added = nullptr;
                 for (auto const &t_prime_node : t_prime.root->get_descendents(false)) // without root
@@ -987,12 +987,12 @@ void Inference::compute_t_prime_scores(Node *attached_node, const vector<vector<
         t_prime.compute_stack(attached_node, d, sum_d,r);
 
         if (is_empty_table)
-            t_prime_scores.push_back(t_prime.get_children_id_score(attached_node));
+            t_prime_scores.push_back(attached_node->get_children_id_score());
         else
         {
             // append the contents of second hashmap into the first
             // note that they cannot have overlapping keys
-            for (auto const& map_item : t_prime.get_children_id_score(attached_node)) // go to each child of the changed node and get its score
+            for (auto const& map_item : attached_node->get_children_id_score()) // go to each child of the changed node and get its score
             {
                 t_prime_scores[j][map_item.first] = map_item.second;
             }

--- a/src/Node.h
+++ b/src/Node.h
@@ -56,6 +56,7 @@ struct Node{
     inline vector<Node*> get_descendents(bool with_n=true) const;
     inline bool first_order_children_repeat_genotype() const;
     inline double compute_event_prior(u_int n_regions) const;
+    inline map<int, double> get_children_id_score() const;
 
     // copy constructor
     Node(Node& source_node): c(source_node.c), c_hash(source_node.c_hash), c_change(source_node.c_change)
@@ -281,6 +282,32 @@ double Node::compute_event_prior(u_int n_regions) const {
     pv_i -= c_penalisation*repetition_count; // penalise the repetitions
 
     return pv_i;
+}
+
+map<int, double> Node::get_children_id_score() const {
+/*
+ * Returns the ids and the log scores of the descendent nodes
+ * Throws std::logic_error
+ * */
+
+    map<int,double> id_score_pairs;
+
+    // stack based implementation
+    std::stack<Node*> stk;
+    stk.push(const_cast<Node*> (this));
+
+    while (!stk.empty()) {
+        Node* top = static_cast<Node*> (stk.top());
+        stk.pop();
+        for (Node* temp = top->first_child; temp != nullptr; temp=temp->next) {
+            stk.push(temp);
+        }
+        // make sure the id is not in the map before
+        if (id_score_pairs.find(top->id) != id_score_pairs.end())
+            throw std::logic_error("the id of the node should not be in the map already");
+        id_score_pairs[top->id] = top->attachment_score;
+    }
+    return id_score_pairs;
 }
 
 #endif //SC_DNA_NODE_H

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -83,9 +83,9 @@ public:
     //validation of tree
     bool is_redundant() const;
     // Validation of subtrees
-    bool is_valid_subtree(Node* node) const;// TODO: can be a method of node instead
-    bool subtree_out_of_bound(Node *n) const;// TODO: can be a method of node instead
-    bool zero_ploidy_changes(Node* n) const;// TODO: can be a method of node instead
+    bool is_valid_subtree(Node* node) const;
+    bool subtree_out_of_bound(Node *n) const;
+    bool zero_ploidy_changes(Node* n) const;
     double cost();
 
     vector<double> omega_condense_split(double lambda_s, bool weighted, bool max_scoring);

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -74,7 +74,6 @@ public:
     void random_insert(std::map<u_int, int>&&);
     void insert_at(u_int pos, std::map<u_int, int>&&); // uses all_nodes_vec pos
     void insert_child(Node *pos, std::map<u_int, int>&& labels);
-    map<int, double> get_children_id_score(Node *node); // TODO: can be a method of node instead
     void compute_tree(const vector<double> &D, const vector<int> &r);
     void compute_stack(Node *node, const vector<double> &D, double &sum_D, const vector<int> &r);
     void compute_weights();
@@ -769,32 +768,6 @@ void Tree::load_from_file(string file) {
 
     compute_weights();
 
-}
-
-map<int, double> Tree::get_children_id_score(Node *node) { // TODO: make it a method of node instead
-/*
- * Returns the ids and the log scores of the descendent nodes
- * Throws std::logic_error
- * */
-
-    map<int,double> id_score_pairs;
-
-    // stack based implementation
-    std::stack<Node*> stk;
-    stk.push(node);
-
-    while (!stk.empty()) {
-        Node* top = static_cast<Node*> (stk.top());
-        stk.pop();
-        for (Node* temp = top->first_child; temp != nullptr; temp=temp->next) {
-            stk.push(temp);
-        }
-        // make sure the id is not in the map before
-        if (id_score_pairs.find(top->id) != id_score_pairs.end())
-            throw std::logic_error("the id of the node should not be in the map already");
-        id_score_pairs[top->id] = top->attachment_score;
-    }
-    return id_score_pairs;
 }
 
 void Tree::compute_weights() {

--- a/tests/validation.h
+++ b/tests/validation.h
@@ -90,9 +90,9 @@ void test_ploidy_attachment_score()
     vector<double> counts = {10, 40, 80, 120, 500};
 
     t_two.compute_tree(counts, reg_sizes);
-    std::map<int, double> scores_vec = t_two.get_children_id_score(t_two.root);
+    std::map<int, double> scores_vec = t_two.root->get_children_id_score();
     t_three.compute_tree(counts, reg_sizes);
-    std::map<int, double> scores_vec_prime = t_three.get_children_id_score(t_three.root);
+    std::map<int, double> scores_vec_prime = t_three.root->get_children_id_score();
 
     assert(scores_vec[0]==scores_vec_prime[0]);
     cout<<"Cell attachment with different ploidies validation test passed!"<<endl;
@@ -339,7 +339,7 @@ void test_condense_split_weights()
     for (size_t i = 0; i < n_cells; ++i)
     {
         t_prime.compute_tree(D[i], r);
-        std::map<int, double> scores_vec_prime = t_prime.get_children_id_score(t_prime.root);
+        std::map<int, double> scores_vec_prime = t_prime.root->get_children_id_score();
         t_prime_scores.push_back(scores_vec_prime);
         t_prime_sums.push_back(MathOp::log_sum(scores_vec_prime));
     }
@@ -421,7 +421,7 @@ void test_condense_split_weights()
     for (size_t i = 0; i < n_cells; ++i)
     {
         t_max_prime.compute_tree(D[i], r);
-        std::map<int, double> scores_vec_prime_max = t_max_prime.get_children_id_score(t_max_prime.root);
+        std::map<int, double> scores_vec_prime_max = t_max_prime.root->get_children_id_score();
         t_max_prime_scores.push_back(scores_vec_prime_max);
 
         double currentMax = -DBL_MAX;
@@ -503,7 +503,7 @@ void test_insert_delete_weights()
     for (size_t i = 0; i < n_cells; ++i)
     {
         t.compute_tree(D[i], r);
-        std::map<int, double> scores_vec = t.get_children_id_score(t.root);
+        std::map<int, double> scores_vec = t.root->get_children_id_score();
 
         t_scores.push_back(scores_vec);
         t_sums.push_back(MathOp::log_sum(scores_vec));
@@ -567,7 +567,7 @@ void test_insert_delete_weights()
     for (size_t i = 0; i < n_cells; ++i)
     {
         t_max.compute_tree(D[i], r);
-        std::map<int, double> scores_vec = t_max.get_children_id_score(t_max.root);
+        std::map<int, double> scores_vec = t_max.root->get_children_id_score();
 
         t_max_scores.push_back(scores_vec);
 


### PR DESCRIPTION
`get_children_id_score` returns the ids and the log scores of the descendant nodes of a given Node (not a Tree).
It is more meaningful to be a method of Node.

The method calls get simplified.
E.g. 

This

`t_prime_scores.push_back(t_prime.get_children_id_score(attached_node));`

becomes this

`t_prime_scores.push_back(attached_node->get_children_id_score());`


Removed old TODO items in Tree.h.